### PR TITLE
Tidy principles for genomic ranges manipulation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -96,6 +96,7 @@ Imports:
     rtracklayer,
     GenomicRanges,
     BSgenome, 
-    tidyomics
+    tidyomics, 
+    airway
 URL: https://github.com/bioconductor/BiocHowTo, 
     https://bioconductor.github.io/BiocHowTo/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -97,6 +97,7 @@ Imports:
     GenomicRanges,
     BSgenome, 
     tidyomics, 
-    airway
+    airway, 
+    readxl
 URL: https://github.com/bioconductor/BiocHowTo, 
     https://bioconductor.github.io/BiocHowTo/

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -23,6 +23,7 @@ articles:
 
 - title: Tidy principles in Bioconductor
   contents:
+  - how-to-use-tidy-principles-for-granges-manipulation
   - how-to-use-tidy-principles-for-rna-seq-analysis
 
 - title: Accessing genomic annotation data

--- a/inst/references.bib
+++ b/inst/references.bib
@@ -1,0 +1,13 @@
+@article{Serizay2020Oct,
+	author = {Serizay, Jacques and Dong, Yan and J{\ifmmode\ddot{a}\else\"{a}\fi}nes, J{\ifmmode\ddot{u}\else\"{u}\fi}rgen and Chesney, Michael and Cerrato, Chiara and Ahringer, Julie},
+	title = {{Distinctive regulatory architectures of germline-active and somatic genes in C. elegans}},
+	journal = {Genome Res.},
+	volume = {30},
+	number = {12},
+	pages = {1752--1765},
+	year = {2020},
+	month = oct,
+	issn = {1088-9051},
+	publisher = {Cold Spring Harbor Lab},
+	doi = {10.1101/gr.265934.120}
+}

--- a/vignettes/how-to-use-tidy-principles-for-granges-manipulation.qmd
+++ b/vignettes/how-to-use-tidy-principles-for-granges-manipulation.qmd
@@ -1,0 +1,184 @@
+---
+title: How to use tidy principles for genomic ranges manipulation
+author: Jacques Serizay
+date: "`r Sys.Date()`"
+vignette: >
+  %\VignetteIndexEntry{How to use tidy principles for genomic ranges manipulation}
+  %\VignetteEngine{quarto::html}
+  %\VignetteEncoding{UTF-8}
+knitr:
+    opts_chunk: 
+        collapse: true
+        comment: '#>'
+format:
+    html:
+        toc: true
+        html-math-method: mathjax
+bibliography: ../inst/references.bib
+---
+
+```{r}
+#| echo: false
+
+suppressPackageStartupMessages({
+    library(BiocStyle)
+})
+```
+
+Tidy data principles are a set of principles for structuring data in a way 
+that makes it easier to manipulate and analyze. They have been popularized by the
+`tidyverse` collection of R packages, which includes `dplyr` for data manipulation 
+and `ggplot2` for data visualization. The tidy principles can also be applied to
+biological data, such as RNA-seq data, to facilitate analysis and visualization, 
+thanks to the `tidyomics` meta-package.
+
+# Bioconductor packages used in this document
+
+* `r Biocpkg("tidyomics")`
+
+# How to manipulate GRanges objects with tidy principles
+
+For illustration, we are going to download a `xlsx` file provided as a 
+Supplementary Data in [@Serizay2020Oct], and manipulate it using tidy principles.
+
+Good practices recommended by the Bioconductor consortium suggest to use 
+the `BiocFileCache` package to download and cache files from remote servers.
+
+```{r}
+library(BiocFileCache)
+
+# Create a BiocFileCache instance
+bfc <- BiocFileCache()
+
+# Download the xlsx file from Ensembl and cache it locally using BiocFileCache
+xlsx_url <- "https://genome.cshlp.org/content/suppl/2020/11/16/gr.265934.120.DC1/Supplemental_Table_S2.xlsx"
+xlsx_file <- bfcrpath(bfc, xlsx_url)
+
+# The file is now downloaded and available
+xlsx_file
+```
+
+Excel files can be read into `tibbles` in `R` thanks to the `read_xlsx()` function 
+from the `readxl` package.
+
+```{r}
+library(readxl)
+tbl <- read_xlsx(xlsx_file, sheet = "ATAC_metrics", skip = 2)
+tbl
+```
+
+We convert it into a `GRanges` object directly using `as_granges()` from the `plyranges` package, 
+using [tidy evaluation as in `dplyr` package](https://dplyr.tidyverse.org/articles/programming.html). 
+
+```{r}
+library(plyranges)
+gr <- tbl |> 
+    as_granges(seqnames = chrom_ce11, start = start_ce11, end = end_ce11)
+gr
+```
+
+Let's say we are not interested in all the metadata columns, and we want to keep only the
+`annot_dev_age_tissues`, `Annotation`, and the columns ending with `_RPM`. 
+We can use the `select()` function from `dplyr` to select these columns, 
+just like we would do with a `data.frame` or `tibble`.
+
+```{r}
+library(tidyverse)
+gr <- gr |> 
+    select(annot_dev_age_tissues, Annotation, ends_with("_RPM"))
+gr
+```
+
+In fact, most verbs from the `dplyr` package can be used with `GRanges` objects,
+such as `filter()`, `mutate()`, `arrange()`, `group_by()` and `summarise()`. 
+
+```{r}
+gr |> 
+    mutate(start = start - 1000, end = end + 1000) |>
+    filter(start > 1e6) |>
+    arrange(Intest._RPM) |>
+    group_by(annot_dev_age_tissues, Annotation) |> 
+    summarize(n = plyranges::n()) 
+```
+
+Note that the `summarize()` function automatically returns a `DataFrame`, not a `GRanges` object. 
+
+To enhance compatibility with the `tidyverse` ecosystem, the `plyranges` package
+provides a `as_tibble()` method for `GRanges` objects, which converts them
+into `tibbles`. This allows you to use pass `GRanges` objects to `ggplot` for visualization. 
+
+```{r}
+gr |> 
+    filter(Annotation %in% c("Intest.", "Hypod.", "Soma", "Ubiq.")) |>
+    as_tibble() |> 
+    ggplot(aes(x = `Intest._RPM`, y = `Hypod._RPM`, color = Annotation)) +
+    geom_point() +
+    labs(x = "Intestine RPM", y = "Hypodermis RPM") + 
+    facet_grid(Annotation~annot_dev_age_tissues) +
+    theme_bw() +
+    theme(legend.position = "bottom")
+```
+
+Finally, the `join` concept introduced by the `dplyr` package can also be applied to `GRanges` objects.
+In this case, the operation refers to joining overlapping, nearest, or preceding/following ranges, 
+using the `join_*_*()` function from the `plyranges` package.
+
+As an example, we can compare annotations from [@Serizay2020Oct] to chromosome 
+arms/center 
+
+```{r}
+arms <- GRanges(
+    seqnames = rep(c("chrI", "chrII", "chrIII", "chrIV", "chrV", "chrX"), each = 3),
+    ranges = IRanges(
+        start = c(
+            1, 4550001, 10750001, 
+            1, 4550001, 10750001, 
+            1, 4450001, 10150001, 
+            1, 4750001, 12650001, 
+            1, 4850001, 16250001, 
+            1, 2850001, 14250001
+        ), 
+        end = c(
+            4550000, 10750000, 15072423, 
+            4550000, 10750000, 15279345,
+            4450000, 10150000, 13783700,
+            4750000, 12650000, 17493793,
+            4850000, 16250000, 20924149,
+            2850000, 14250000, 17718866
+        )
+    ),
+    strand = "*",
+    part = rep(c("arm", "center", "arm"), 6)
+)
+
+gr |> 
+    join_overlap_left(arms) |> 
+    group_by(Annotation, part) |>
+    filter(Annotation %in% c("Germline", "Neurons")) |>
+    summarize(n = plyranges::n()) 
+```
+
+# Further reading 
+
+To read more about the `tidyomics` packages, please refer to the
+[tidyomics](https://github.com/tidyomics) GitHub organization page. 
+
+More tutorials are provided by the `tidyomics` GitHub organization in the 
+[tidy-ranges-tutorial](https://tidyomics.github.io/tidy-ranges-tutorial/) website. 
+
+# References
+
+::: {#refs}
+:::
+
+# Session info
+
+<details>
+<summary><b>
+Click to display session info
+</b></summary>
+```{r}
+sessionInfo()
+```
+</details>
+

--- a/vignettes/how-to-use-tidy-principles-for-granges-manipulation.qmd
+++ b/vignettes/how-to-use-tidy-principles-for-granges-manipulation.qmd
@@ -71,7 +71,7 @@ We convert it into a `GRanges` object directly using `as_granges()` from the `pl
 using [tidy evaluation as in `dplyr` package](https://dplyr.tidyverse.org/articles/programming.html). 
 
 ```{r}
-library(plyranges)
+library(tidyomics)
 gr <- tbl |> 
     as_granges(seqnames = chrom_ce11, start = start_ce11, end = end_ce11)
 gr
@@ -83,7 +83,6 @@ We can use the `select()` function from `dplyr` to select these columns,
 just like we would do with a `data.frame` or `tibble`.
 
 ```{r}
-library(tidyverse)
 gr <- gr |> 
     select(annot_dev_age_tissues, Annotation, ends_with("_RPM"))
 gr

--- a/vignettes/how-to-use-tidy-principles-for-rna-seq-analysis.qmd
+++ b/vignettes/how-to-use-tidy-principles-for-rna-seq-analysis.qmd
@@ -37,47 +37,48 @@ thanks to the `tidyomics` meta-package.
 
 # How to manipulate SummarizedExperiment objects with tidy principles
 
-For illustration, we use data from the `r Biocpkg("tidySummarizedExperiment")` 
-package (included in the meta-package `r Biocpkg("tidyomics")`). 
+For illustration, we use data from the `r Biocpkg("airway")` package. 
 
 ```{r}
 library(tidyomics)
+data(airway, package="airway")
 
-pasilla_tidy <- tidySummarizedExperiment::pasilla 
-pasilla_tidy
+airway
 ```
 
-How `pasilla_tidy` object is printed is controlled by the `tidySummarizedExperiment` package, 
+How `airway` object is printed is controlled by the `tidySummarizedExperiment` package, 
 and by default it is displayed as a `tibble`-like object. Note that this 
 behavior can be changed by setting the `options(restore_SummarizedExperiment_show = TRUE)` option. 
 
 ```{r}
 # Turn off the tibble visualisation
 options("restore_SummarizedExperiment_show" = TRUE)
-pasilla_tidy
+airway
 
 # Turn on the tibble visualisation
 options("restore_SummarizedExperiment_show" = FALSE)
-pasilla_tidy
+airway
 ```
 
-The `pasilla_tidy` object is a `SummarizedExperiment` object, and the 
+The `airway` object is a `SummarizedExperiment` object, and the 
 `tidySummarizedExperiment` packages adds an invisible layer to abstract the `SE` object as a
 `tibble`. This allows us to use the `dplyr` package to manipulate the data, and eventually 
 to directly plug data flow into `ggplot2` for visualization.
 
 ```{r}
-pasilla_tidy |> 
-    filter(condition == "untreated", type == "single_end") |> 
-    select(-type) |> 
-    group_by(.feature, .sample) |> 
+airway |> 
+    filter(albut == "untrt") |> 
+    group_by(.feature, dex) |> 
     summarise(tot_counts = sum(counts)) |>
-    ggplot(aes(x = .sample, y = tot_counts+1, fill = .sample)) + 
-    geom_violin() + 
-    geom_boxplot(outliers = FALSE, width = 0.05, fill = "white") +
+    pivot_wider(names_from = dex, values_from = tot_counts) |>
+    slice_sample(n = 10000) |> 
+    ggplot(aes(x = trt, y = untrt)) + 
+    geom_density_2d(color = "black", linewidth = 0.5) +
+    geom_point(alpha = 0.1, size = 0.3) + 
+    scale_x_log10() + 
     scale_y_log10() + 
-    annotation_logticks(side = 'l') +
-    labs(x = "Sample", y = "Total counts (log1p)") +
+    annotation_logticks(side = 'bl') +
+    labs(x = "Dex treated", y = "Dex untreated") +
     theme_bw()
 ```
 


### PR DESCRIPTION
Examples of: 
- `as_granges()`
- dplyr functionalities ported to GRanges
- GRanges passed to ggplot with `as_tibble()`
- `join_overlap_left()`